### PR TITLE
add matchTriggerWidth

### DIFF
--- a/addon/components/power-select-with-fallback.js
+++ b/addon/components/power-select-with-fallback.js
@@ -11,6 +11,9 @@ export default Ember.Component.extend({
   layout,
   tagName: '',
 
+  matchTriggerWidth: true,
+
+
   // CPs
   mustFallback: computed('fallback-when', function() {
     let fallbackStrategy = this.get('fallback-when');

--- a/addon/templates/components/power-select-with-fallback.hbs
+++ b/addon/templates/components/power-select-with-fallback.hbs
@@ -53,6 +53,7 @@
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent
       matcher=matcher
+      matchTriggerWidth=matchTriggerWidth
       searchField=searchField
       renderInPlace=renderInPlace
       search=search
@@ -93,6 +94,7 @@
       optionsComponent=optionsComponent
       afterOptionsComponent=afterOptionsComponent
       matcher=matcher
+      matchTriggerWidth=matchTriggerWidth
       searchField=searchField
       renderInPlace=renderInPlace
       search=search

--- a/addon/templates/components/power-select-with-fallback.hbs
+++ b/addon/templates/components/power-select-with-fallback.hbs
@@ -59,6 +59,7 @@
       search=search
       allowClear=allowClear
       verticalPosition=verticalPosition
+      horizontalPosition=horizontalPosition
       closeOnSelect=closeOnSelect
       opened=opened
       tabindex=tabindex
@@ -100,6 +101,7 @@
       search=search
       allowClear=allowClear
       verticalPosition=verticalPosition
+      horizontalPosition=horizontalPosition
       closeOnSelect=closeOnSelect
       opened=opened
       tabindex=tabindex


### PR DESCRIPTION
Adding matchTriggerWidth to library the default is true.... I like the opposite default but we can overwrite where it does not match our purposes

http://www.ember-power-select.com/docs/api-reference

Need to get this into slate.. not sure if that uses npm-shrinkwrap or not - but its set on `#master` to this